### PR TITLE
feat(haproxy): enable dynamic load balancing for SDK replicas using server-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ It is designed for **DFSPs (Digital Financial Service Providers)** who need a si
    - `--profile admin` (for portainer service for debugging purposes)
    - `--profile ttk` (for testing toolkit for testing purposes)
 
+Optional: Scale SDK replicas
+
+By default, the SDK runs as a single replica.
+For higher availability and load distribution, you can scale the SDK to multiple replicas.
+Example: Run with 3 SDK replicas:
+   - ` --scale sdk-scheme-adapter=3` (for testing toolkit for testing purposes)
 
 ## Accessing Services
 

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -157,9 +157,7 @@ backend certbot_webroot_backend
 backend sdk_scheme_adapter_backend
     mode tcp
     balance roundrobin
-    ## Without dynamic DNS resolution
-    # server sdk_scheme_adapter1 sdk-scheme-adapter:4000 check
-    ## To use dynamic DNS resolution with single replica
-    server sdk_scheme_adapter1 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
-    ## To use dynamic DNS resolution with multiple replicas
-    # server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
+    # Use Docker DNS resolver to dynamically discover multiple SDK replicas
+    resolvers docker
+    # Multi-replica dynamic DNS resolution (works for 1 replica or 3+)
+    server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check init-addr none

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -165,3 +165,4 @@ backend sdk_scheme_adapter_backend
     # server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
     # Multi-replica dynamic DNS resolution (works for 1 replica or 3+)
     server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check init-addr none
+    

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -157,6 +157,12 @@ backend certbot_webroot_backend
 backend sdk_scheme_adapter_backend
     mode tcp
     balance roundrobin
+    ## Without dynamic DNS resolution
+    # server sdk_scheme_adapter1 sdk-scheme-adapter:4000 check
+    ## To use dynamic DNS resolution with single replica
+    ## server sdk_scheme_adapter1 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
+    ## To use dynamic DNS resolution with multiple replicas
+    # server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
     # Use Docker DNS resolver to dynamically discover multiple SDK replicas
     resolvers docker
     # Multi-replica dynamic DNS resolution (works for 1 replica or 3+)

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -163,7 +163,5 @@ backend sdk_scheme_adapter_backend
     ## server sdk_scheme_adapter1 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
     ## To use dynamic DNS resolution with multiple replicas
     # server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
-    # Use Docker DNS resolver to dynamically discover multiple SDK replicas
-    resolvers docker
     # Multi-replica dynamic DNS resolution (works for 1 replica or 3+)
     server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check init-addr none

--- a/docker/haproxy/haproxy.cfg
+++ b/docker/haproxy/haproxy.cfg
@@ -165,4 +165,3 @@ backend sdk_scheme_adapter_backend
     # server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check
     # Multi-replica dynamic DNS resolution (works for 1 replica or 3+)
     server-template sdk 1-5 sdk-scheme-adapter:4000 resolvers docker resolve-prefer ipv4 check init-addr none
-    


### PR DESCRIPTION
This PR updates HAProxy sdk_scheme_adapter_backend to use server-template with Docker DNS instead of a single server entry